### PR TITLE
allow for dv profile 10 (av01)

### DIFF
--- a/app/src/main/java/com/hritwik/avoid/utils/helpers/CodecDetector.kt
+++ b/app/src/main/java/com/hritwik/avoid/utils/helpers/CodecDetector.kt
@@ -518,6 +518,7 @@ object CodecDetector {
                             MediaCodecInfo.CodecProfileLevel.DolbyVisionProfileDvavPer -> "Profile 0 (dvav.per)"
                             MediaCodecInfo.CodecProfileLevel.DolbyVisionProfileDvavPen -> "Profile 1 (dvav.pen)"
                             MediaCodecInfo.CodecProfileLevel.DolbyVisionProfileDvavSe -> "Profile 9 (dvav.se)"
+                            MediaCodecInfo.CodecProfileLevel.DolbyVisionProfileDvav110 -> "Profile 10 (dvav.av1)"
                             else -> "Profile ${profileLevel.profile}"
                         }
                         if (!profiles.contains(profileName)) {


### PR DESCRIPTION
as exoplayer already supports it.
~Although playback might still be wrong somewhere? Duration of movie is always at 1 second. Native Jellyfin App shows correct time.~
File was just broken :)
