### PR TITLE
Add local trailer playback actions to media detail screens

### DIFF
--- a/app/src/main/java/com/hritwik/avoid/data/remote/JellyfinApiService.kt
+++ b/app/src/main/java/com/hritwik/avoid/data/remote/JellyfinApiService.kt
@@ -334,6 +334,17 @@ interface JellyfinApiService {
         @Header("X-Emby-Authorization") authorization: String
     ): List<BaseItemDto>
 
+    @GET("Items/{itemId}/LocalTrailers")
+    suspend fun getLocalTrailers(
+        @Path("itemId") itemId: String,
+        @Query("UserId") userId: String,
+        @Query("Fields") fields: String = ApiConstants.FIELDS_FULL,
+        @Query("EnableImageTypes") enableImageTypes: String? = "Primary",
+        @Query("EnableImages") enableImages: Boolean = true,
+        @Query("EnableUserData") enableUserData: Boolean = true,
+        @Header("X-Emby-Authorization") authorization: String
+    ): List<BaseItemDto>
+
     @GET("MediaSegments/{itemId}")
     suspend fun getItemSegments(
         @Path("itemId") itemId: String,

--- a/app/src/main/java/com/hritwik/avoid/data/repository/LibraryRepositoryImpl.kt
+++ b/app/src/main/java/com/hritwik/avoid/data/repository/LibraryRepositoryImpl.kt
@@ -56,6 +56,7 @@ import android.util.Log
 import com.hritwik.avoid.utils.helpers.NetworkMonitor
 import com.hritwik.avoid.utils.helpers.normalizeUuid
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
@@ -1642,6 +1643,28 @@ class LibraryRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getLocalTrailers(
+        mediaId: String,
+        userId: String,
+        accessToken: String
+    ): NetworkResult<List<MediaItem>> {
+        val serverUrl = getServerUrl()
+        return safeApiCall(serverUrl) {
+            val apiService = createApiService(serverUrl)
+
+            val authHeader = JellyfinApiService.createAuthHeader(deviceId, token = accessToken)
+            val response = apiService.getLocalTrailers(
+                itemId = mediaId,
+                userId = userId,
+                authorization = authHeader
+            )
+
+            response.map { dto ->
+                mapToMediaItem(dto)
+            }
+        }
+    }
+
     override suspend fun getMediaCredits(
         userId: String,
         mediaId: String,
@@ -1695,7 +1718,20 @@ class LibraryRepositoryImpl @Inject constructor(
             ).map { dto ->
                 mapToMediaItem(dto)
             }
-            RelatedResources(similar, special)
+            val localTrailers = try {
+                apiService.getLocalTrailers(
+                    itemId = mediaId,
+                    userId = userId,
+                    authorization = authHeader
+                ).map { dto ->
+                    mapToMediaItem(dto)
+                }
+            } catch (cancellationException: CancellationException) {
+                throw cancellationException
+            } catch (_: Exception) {
+                emptyList()
+            }
+            RelatedResources(similar, special, localTrailers)
         }
     }
 

--- a/app/src/main/java/com/hritwik/avoid/domain/repository/LibraryRepository.kt
+++ b/app/src/main/java/com/hritwik/avoid/domain/repository/LibraryRepository.kt
@@ -19,7 +19,8 @@ import com.hritwik.avoid.utils.constants.ApiConstants
 
 data class RelatedResources(
     val similar: List<MediaItem>,
-    val special: List<MediaItem>
+    val special: List<MediaItem>,
+    val localTrailers: List<MediaItem> = emptyList()
 )
 
 interface LibraryRepository {
@@ -186,6 +187,11 @@ interface LibraryRepository {
         limit: Int = 10
     ): NetworkResult<List<MediaItem>>
     suspend fun getSpecialFeatures(
+        mediaId: String,
+        userId: String,
+        accessToken: String
+    ): NetworkResult<List<MediaItem>>
+    suspend fun getLocalTrailers(
         mediaId: String,
         userId: String,
         accessToken: String

--- a/app/src/main/java/com/hritwik/avoid/presentation/ui/components/media/MediaActionButtons.kt
+++ b/app/src/main/java/com/hritwik/avoid/presentation/ui/components/media/MediaActionButtons.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -79,9 +80,11 @@ fun MediaActionButtons(
     mediaItem: MediaItem,
     serverUrl: String,
     playbackItem: MediaItem? = null,
+    localTrailers: List<MediaItem> = emptyList(),
     onPlayClick: (PlaybackInfo) -> Unit,
     playButtonSize: Int = 48,
     showFavIcon: Boolean = true,
+    isMovie: Boolean = true,
     playButtonFocusRequester: FocusRequester? = null,
     authViewModel: AuthServerViewModel = hiltViewModel(),
     userDataViewModel: UserDataViewModel = hiltViewModel(),
@@ -212,16 +215,34 @@ fun MediaActionButtons(
         }
     }
 
+    val playTrailer: () -> Unit = {
+        localTrailers.firstOrNull()?.let { trailer ->
+            val source = trailer.mediaSources.firstOrNull()
+            val playbackInfo = PlaybackInfo(
+                mediaItem = trailer,
+                mediaSourceId = source?.id,
+                audioStreamIndex = source?.defaultAudioStream?.index,
+                subtitleStreamIndex = source?.defaultSubtitleStream?.index,
+                startPosition = 0L,
+                maxBitrate = source?.bitrate
+            )
+            onPlayClick(playbackInfo)
+        }
+    }
+
+    val hasLocalTrailers = localTrailers.isNotEmpty()
     val playFocusRequester = playButtonFocusRequester ?: remember { FocusRequester() }
     val versionFocusRequester = remember { FocusRequester() }
     val audioFocusRequester = remember { FocusRequester() }
     val subtitleFocusRequester = remember { FocusRequester() }
     val favoriteFocusRequester = remember(showFavIcon) { if (showFavIcon) FocusRequester() else null }
+    val trailerFocusRequester = remember { FocusRequester() }
 
     val versionInteractionSource = remember { MutableInteractionSource() }
     val audioInteractionSource = remember { MutableInteractionSource() }
     val subtitleInteractionSource = remember { MutableInteractionSource() }
     val favoriteInteractionSource = remember { MutableInteractionSource() }
+    val trailerInteractionSource = remember { MutableInteractionSource() }
     val videoCodecText = playbackOptions.selectedVideoStream?.codec
         ?.takeIf { it.isNotBlank() }
         ?.trim()
@@ -270,71 +291,84 @@ fun MediaActionButtons(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(calculateRoundedValue(14).sdp)
                 ){
-                    Box(
-                        modifier = Modifier
-                            .size(haloContainerSize)
-                            .graphicsLayer {
-                                val scale = 1f + (haloScale - 1f) * haloProgress
-                                scaleX = scale
-                                scaleY = scale
-                            },
-                        contentAlignment = Alignment.Center
-                    ) {
-                        if (haloBorderWidth > 0.dp && haloProgress > 0f) {
-                            Box(
-                                modifier = Modifier
-                                    .size(playButtonSize + haloBorderWidth * 2)
-                                    .border(
-                                        width = haloBorderWidth,
-                                        brush = Brush.linearGradient(
-                                            colors = listOf(
-                                                Color.White.copy(alpha = 0.9f * haloProgress),
-                                                lerp(buttonColor, Color.White, 0.6f).copy(alpha = haloProgress)
-                                            ),
-                                            start = Offset(0f, 0f),
-                                            end = Offset(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY)
-                                        ),
-                                        shape = CircleShape
-                                    )
-                                    .graphicsLayer { alpha = haloProgress },
-                                contentAlignment = Alignment.Center
-                            ) {}
-                        }
-
-                        DynamicPlayButton(
+                    if (isMovie) {
+                        Box(
                             modifier = Modifier
-                                .size(playButtonSize)
-                                .dpadNavigation(
-                                    focusRequester = playFocusRequester,
-                                    interactionSource = playInteractionSource,
-                                    onClick = playMovie,
-                                    onMoveFocus = { direction ->
-                                        when (direction) {
-                                            FocusDirection.Right -> {
-                                                favoriteFocusRequester?.requestFocus()
-                                                true
+                                .size(haloContainerSize)
+                                .graphicsLayer {
+                                    val scale = 1f + (haloScale - 1f) * haloProgress
+                                    scaleX = scale
+                                    scaleY = scale
+                                },
+                            contentAlignment = Alignment.Center
+                        ) {
+                            if (haloBorderWidth > 0.dp && haloProgress > 0f) {
+                                Box(
+                                    modifier = Modifier
+                                        .size(playButtonSize + haloBorderWidth * 2)
+                                        .border(
+                                            width = haloBorderWidth,
+                                            brush = Brush.linearGradient(
+                                                colors = listOf(
+                                                    Color.White.copy(alpha = 0.9f * haloProgress),
+                                                    lerp(buttonColor, Color.White, 0.6f).copy(alpha = haloProgress)
+                                                ),
+                                                start = Offset(0f, 0f),
+                                                end = Offset(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY)
+                                            ),
+                                            shape = CircleShape
+                                        )
+                                        .graphicsLayer { alpha = haloProgress },
+                                    contentAlignment = Alignment.Center
+                                ) {}
+                            }
+
+                            DynamicPlayButton(
+                                modifier = Modifier
+                                    .size(playButtonSize)
+                                    .dpadNavigation(
+                                        focusRequester = playFocusRequester,
+                                        interactionSource = playInteractionSource,
+                                        onClick = playMovie,
+                                        onMoveFocus = { direction ->
+                                            when (direction) {
+                                                FocusDirection.Right -> {
+                                                    when {
+                                                        favoriteFocusRequester != null -> {
+                                                            favoriteFocusRequester.requestFocus()
+                                                            true
+                                                        }
+
+                                                        hasLocalTrailers -> {
+                                                            trailerFocusRequester.requestFocus()
+                                                            true
+                                                        }
+
+                                                        else -> false
+                                                    }
+                                                }
+                                                else -> false
                                             }
-                                            else -> false
-                                        }
-                                    },
-                                    applyClickModifier = false,
-                                    showFocusOutline = false
-                                ),
-                            onClick = playMovie,
-                            dominantColor = buttonColor,
-                            buttonSize = playButtonSize,
-                            iconSize = (playButtonSize.value / 2).dp,
-                            mediaItem = playbackItemForActions,
-                            hasResumableProgress = hasResumableProgress,
-                            focusRequester = playFocusRequester
-                        )
+                                        },
+                                        applyClickModifier = false,
+                                        showFocusOutline = false
+                                    ),
+                                onClick = playMovie,
+                                dominantColor = buttonColor,
+                                buttonSize = playButtonSize,
+                                iconSize = (playButtonSize.value / 2).dp,
+                                mediaItem = playbackItemForActions,
+                                hasResumableProgress = hasResumableProgress,
+                                focusRequester = playFocusRequester
+                            )
+                        }
                     }
 
                     if (showFavIcon) {
                         val favoriteRequester = favoriteFocusRequester
                         if (favoriteRequester != null) {
                             Box(
-                                modifier = Modifier.padding(start = calculateRoundedValue(16).sdp)
+                                modifier = Modifier.padding(start = if (isMovie) calculateRoundedValue(16).sdp else 0.sdp)
                             ) {
                                 MediaFavoriteChip(
                                     modifier = Modifier.focusRequester(favoriteRequester),
@@ -355,12 +389,30 @@ fun MediaActionButtons(
                                     onMoveFocus = { direction ->
                                         when (direction) {
                                             FocusDirection.Left -> {
-                                                playFocusRequester.requestFocus()
-                                                true
+                                                when {
+                                                    isMovie -> {
+                                                        playFocusRequester.requestFocus()
+                                                        true
+                                                    }
+
+                                                    else -> false
+                                                }
                                             }
+
                                             FocusDirection.Right -> {
-                                                versionFocusRequester.requestFocus()
-                                                true
+                                                when {
+                                                    hasLocalTrailers -> {
+                                                        trailerFocusRequester.requestFocus()
+                                                        true
+                                                    }
+
+                                                    isMovie -> {
+                                                        versionFocusRequester.requestFocus()
+                                                        true
+                                                    }
+
+                                                    else -> false
+                                                }
                                             }
                                             else -> false
                                         }
@@ -370,105 +422,163 @@ fun MediaActionButtons(
                         }
                     }
 
-                    Row(
-                        modifier = Modifier.padding(start = calculateRoundedValue(16).sdp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(calculateRoundedValue(10).sdp)
-                    ) {
-                        EpisodeInfoChip(
-                            label = "Resolution",
-                            value = resolutionLabel ?: "Unknown",
-                            accentColor = buttonColor
-                        )
-                        EpisodeInfoChip(
-                            label = null,
-                            value = playbackState.currentVideoRangeText,
-                            accentColor = buttonColor
-                        )
+                    if (hasLocalTrailers) {
+                        Box(
+                            modifier = Modifier.padding(start = calculateRoundedValue(16).sdp)
+                        ) {
+                            TrailerButton(
+                                modifier = Modifier.focusRequester(trailerFocusRequester),
+                                accentColor = buttonColor,
+                                interactionSource = trailerInteractionSource,
+                                onClick = playTrailer,
+                                onMoveFocus = { direction ->
+                                    when (direction) {
+                                        FocusDirection.Left -> {
+                                            when {
+                                                favoriteFocusRequester != null -> {
+                                                    favoriteFocusRequester.requestFocus()
+                                                    true
+                                                }
+
+                                                isMovie -> {
+                                                    playFocusRequester.requestFocus()
+                                                    true
+                                                }
+
+                                                else -> false
+                                            }
+                                        }
+
+                                        FocusDirection.Right -> {
+                                            if (isMovie) {
+                                                versionFocusRequester.requestFocus()
+                                                true
+                                            } else {
+                                                false
+                                            }
+                                        }
+
+                                        else -> false
+                                    }
+                                }
+                            )
+                        }
+                    }
+
+                    if (isMovie) {
+                        Row(
+                            modifier = Modifier.padding(start = calculateRoundedValue(16).sdp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(calculateRoundedValue(10).sdp)
+                        ) {
+                            EpisodeInfoChip(
+                                label = "Resolution",
+                                value = resolutionLabel ?: "Unknown",
+                                accentColor = buttonColor
+                            )
+                            EpisodeInfoChip(
+                                label = null,
+                                value = playbackState.currentVideoRangeText,
+                                accentColor = buttonColor
+                            )
+                        }
                     }
                 }
 
                 Spacer(modifier.weight(1f))
 
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(calculateRoundedValue(14).sdp)
-                ) {
-                    EpisodeInfoChip(
-                        label = "Version",
-                        value = versionText,
-                        focusRequester = versionFocusRequester,
-                        onClick = { videoPlaybackViewModel.showVersionDialog() },
-                        interactionSource = versionInteractionSource,
-                        accentColor = buttonColor,
-                        baseContainerAlpha = 0.18f,
-                        onMoveFocus = { direction ->
-                            when (direction) {
-                                FocusDirection.Left -> {
-                                    favoriteFocusRequester?.requestFocus()
-                                    true
-                                }
+                if (isMovie) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(calculateRoundedValue(14).sdp)
+                    ) {
+                        EpisodeInfoChip(
+                            label = "Version",
+                            value = versionText,
+                            focusRequester = versionFocusRequester,
+                            onClick = { videoPlaybackViewModel.showVersionDialog() },
+                            interactionSource = versionInteractionSource,
+                            accentColor = buttonColor,
+                            baseContainerAlpha = 0.18f,
+                            onMoveFocus = { direction ->
+                                when (direction) {
+                                    FocusDirection.Left -> {
+                                        when {
+                                            hasLocalTrailers -> {
+                                                trailerFocusRequester.requestFocus()
+                                                true
+                                            }
 
-                                FocusDirection.Right -> {
-                                    audioFocusRequester.requestFocus()
-                                    true
-                                }
+                                            favoriteFocusRequester != null -> {
+                                                favoriteFocusRequester.requestFocus()
+                                                true
+                                            }
 
-                                else -> false
+                                            else -> false
+                                        }
+                                    }
+
+                                    FocusDirection.Right -> {
+                                        audioFocusRequester.requestFocus()
+                                        true
+                                    }
+
+                                    else -> false
+                                }
                             }
-                        }
-                    )
+                        )
 
-                    EpisodeInfoChip(
-                        label = "Audio",
-                        value = audioText,
-                        focusRequester = audioFocusRequester,
-                        onClick = { videoPlaybackViewModel.showAudioDialog() },
-                        interactionSource = audioInteractionSource,
-                        accentColor = buttonColor,
-                        baseContainerAlpha = 0.18f,
-                        onMoveFocus = { direction ->
-                            when (direction) {
-                                FocusDirection.Left -> {
-                                    versionFocusRequester.requestFocus()
-                                    true
+                        EpisodeInfoChip(
+                            label = "Audio",
+                            value = audioText,
+                            focusRequester = audioFocusRequester,
+                            onClick = { videoPlaybackViewModel.showAudioDialog() },
+                            interactionSource = audioInteractionSource,
+                            accentColor = buttonColor,
+                            baseContainerAlpha = 0.18f,
+                            onMoveFocus = { direction ->
+                                when (direction) {
+                                    FocusDirection.Left -> {
+                                        versionFocusRequester.requestFocus()
+                                        true
+                                    }
+
+                                    FocusDirection.Right -> {
+                                        subtitleFocusRequester.requestFocus()
+                                        true
+                                    }
+
+                                    else -> false
                                 }
-
-                                FocusDirection.Right -> {
-                                    subtitleFocusRequester.requestFocus()
-                                    true
-                                }
-
-                                else -> false
                             }
-                        }
-                    )
+                        )
 
-                    EpisodeInfoChip(
-                        label = "Subtitles",
-                        value = subtitleText,
-                        focusRequester = subtitleFocusRequester,
-                        onClick = { videoPlaybackViewModel.showSubtitleDialog() },
-                        interactionSource = subtitleInteractionSource,
-                        accentColor = buttonColor,
-                        baseContainerAlpha = 0.18f,
-                        onMoveFocus = { direction ->
-                            when (direction) {
-                                FocusDirection.Left -> {
-                                    audioFocusRequester.requestFocus()
-                                    true
+                        EpisodeInfoChip(
+                            label = "Subtitles",
+                            value = subtitleText,
+                            focusRequester = subtitleFocusRequester,
+                            onClick = { videoPlaybackViewModel.showSubtitleDialog() },
+                            interactionSource = subtitleInteractionSource,
+                            accentColor = buttonColor,
+                            baseContainerAlpha = 0.18f,
+                            onMoveFocus = { direction ->
+                                when (direction) {
+                                    FocusDirection.Left -> {
+                                        audioFocusRequester.requestFocus()
+                                        true
+                                    }
+                                    else -> false
                                 }
-                                else -> false
                             }
-                        }
-                    )
+                        )
 
-                    EpisodeInfoChip(
-                        label = null,
-                        value = videoCodecText,
-                        accentColor = buttonColor,
-                        baseContainerAlpha = 0.18f
-                    )
+                        EpisodeInfoChip(
+                            label = null,
+                            value = videoCodecText,
+                            accentColor = buttonColor,
+                            baseContainerAlpha = 0.18f
+                        )
+                    }
                 }
             }
         }
@@ -628,6 +738,117 @@ private fun MediaFavoriteChip(
             )
             Text(
                 text = statusText,
+                color = labelColor,
+                style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.SemiBold),
+                fontSize = calculateRoundedValue(10).ssp
+            )
+        }
+    }
+}
+
+@Composable
+private fun TrailerButton(
+    modifier: Modifier = Modifier,
+    accentColor: Color,
+    interactionSource: MutableInteractionSource,
+    onClick: () -> Unit,
+    onMoveFocus: ((FocusDirection) -> Boolean)?
+) {
+    val shape = RoundedCornerShape(calculateRoundedValue(12).sdp)
+    val isFocused by interactionSource.collectIsFocusedAsState()
+    val focusScale by animateFloatAsState(
+        targetValue = if (isFocused) 1.06f else 1f,
+        animationSpec = tween(durationMillis = 220),
+        label = "trailerButtonScale"
+    )
+    val containerStartColor by animateColorAsState(
+        targetValue = if (isFocused) {
+            lerp(accentColor, Color.White, 0.35f).copy(alpha = 0.6f)
+        } else {
+            Color.White.copy(alpha = 0.12f)
+        },
+        animationSpec = tween(durationMillis = 240),
+        label = "trailerButtonStartColor"
+    )
+    val containerEndColor by animateColorAsState(
+        targetValue = if (isFocused) {
+            Color.White.copy(alpha = 0.22f)
+        } else {
+            Color.White.copy(alpha = 0.05f)
+        },
+        animationSpec = tween(durationMillis = 240),
+        label = "trailerButtonEndColor"
+    )
+    val borderWidth by animateDpAsState(
+        targetValue = if (isFocused) calculateRoundedValue(2).sdp else calculateRoundedValue(1).sdp,
+        animationSpec = tween(durationMillis = 220),
+        label = "trailerButtonBorder"
+    )
+    val glowElevation by animateDpAsState(
+        targetValue = if (isFocused) calculateRoundedValue(6).sdp else 0.dp,
+        animationSpec = tween(durationMillis = 220),
+        label = "trailerButtonGlow"
+    )
+    val labelColor by animateColorAsState(
+        targetValue = if (isFocused) Color.White else Color.White.copy(alpha = 0.85f),
+        animationSpec = tween(durationMillis = 200),
+        label = "trailerButtonLabelColor"
+    )
+    val borderBrush: Brush = if (isFocused) {
+        Brush.linearGradient(
+            colors = listOf(
+                Color.White.copy(alpha = 0.9f),
+                accentColor.copy(alpha = 0.8f)
+            )
+        )
+    } else {
+        SolidColor(Color.White.copy(alpha = 0.2f))
+    }
+
+    Surface(
+        modifier = modifier
+            .dpadNavigation(
+                shape = shape,
+                onClick = onClick,
+                onMoveFocus = onMoveFocus,
+                interactionSource = interactionSource,
+                applyClickModifier = false,
+                showFocusOutline = false
+            )
+            .graphicsLayer {
+                scaleX = focusScale
+                scaleY = focusScale
+            },
+        shape = shape,
+        onClick = onClick,
+        interactionSource = interactionSource,
+        border = BorderStroke(borderWidth, borderBrush),
+        color = Color.Transparent,
+        shadowElevation = glowElevation
+    ) {
+        Row(
+            modifier = Modifier
+                .background(
+                    brush = Brush.linearGradient(
+                        colors = listOf(containerStartColor, containerEndColor)
+                    ),
+                    shape = shape
+                )
+                .padding(
+                    horizontal = calculateRoundedValue(12).sdp,
+                    vertical = calculateRoundedValue(5).sdp
+                ),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(calculateRoundedValue(6).sdp)
+        ) {
+            Icon(
+                imageVector = Icons.Filled.PlayArrow,
+                contentDescription = "Trailer",
+                tint = labelColor,
+                modifier = Modifier.size(calculateRoundedValue(14).sdp)
+            )
+            Text(
+                text = "Trailer",
                 color = labelColor,
                 style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.SemiBold),
                 fontSize = calculateRoundedValue(10).ssp

--- a/app/src/main/java/com/hritwik/avoid/presentation/ui/components/media/MediaActionButtons.kt
+++ b/app/src/main/java/com/hritwik/avoid/presentation/ui/components/media/MediaActionButtons.kt
@@ -218,13 +218,17 @@ fun MediaActionButtons(
     val playTrailer: () -> Unit = {
         localTrailers.firstOrNull()?.let { trailer ->
             val source = trailer.mediaSources.firstOrNull()
+            if (source == null) {
+                context.showToast("Trailer unavailable")
+                return@let
+            }
             val playbackInfo = PlaybackInfo(
                 mediaItem = trailer,
-                mediaSourceId = source?.id,
-                audioStreamIndex = source?.defaultAudioStream?.index,
-                subtitleStreamIndex = source?.defaultSubtitleStream?.index,
+                mediaSourceId = source.id,
+                audioStreamIndex = source.defaultAudioStream?.index,
+                subtitleStreamIndex = source.defaultSubtitleStream?.index,
                 startPosition = 0L,
-                maxBitrate = source?.bitrate
+                maxBitrate = source.bitrate
             )
             onPlayClick(playbackInfo)
         }

--- a/app/src/main/java/com/hritwik/avoid/presentation/ui/screen/auth/LoginScreen.kt
+++ b/app/src/main/java/com/hritwik/avoid/presentation/ui/screen/auth/LoginScreen.kt
@@ -217,7 +217,7 @@ fun LoginScreen(
                             }
                             .focusProperties {
                                 up = usernameFR
-                                down = signInFR
+                                down = quickConnectFR
                             }
                             .semantics { contentDescription = "Password field" },
                         enabled = !state.isLoading,
@@ -243,7 +243,7 @@ fun LoginScreen(
                                         when (e.key) {
                                             Key.DirectionDown -> { signInFR.requestFocus(); true }
                                             Key.DirectionRight -> { changeServerFR.requestFocus(); true }
-                                            Key.DirectionUp -> { passwordFR.requestFocus(); true }
+                                            Key.DirectionUp -> true
                                             else -> false
                                         }
                                     } else false
@@ -251,7 +251,7 @@ fun LoginScreen(
                                 .focusProperties {
                                     down = signInFR
                                     right = changeServerFR
-                                    up = passwordFR
+                                    up = quickConnectFR
                                 }
                                 .focusable(),
                             shape = ButtonDefaults.outlinedShape,
@@ -277,7 +277,7 @@ fun LoginScreen(
                                             Key.DirectionDown -> { signInFR.requestFocus(); true }
                                             Key.DirectionLeft -> { quickConnectFR.requestFocus(); true }
                                             Key.DirectionRight -> { signInFR.requestFocus(); true }
-                                            Key.DirectionUp -> { passwordFR.requestFocus(); true }
+                                            Key.DirectionUp -> true
                                             else -> false
                                         }
                                     } else false
@@ -286,7 +286,7 @@ fun LoginScreen(
                                     down = signInFR
                                     left = quickConnectFR
                                     right = signInFR
-                                    up = passwordFR
+                                    up = changeServerFR
                                 }
                                 .focusable(),
                             shape = ButtonDefaults.outlinedShape,
@@ -330,7 +330,7 @@ fun LoginScreen(
                     .onPreviewKeyEvent { e ->
                         if (e.type == KeyEventType.KeyDown) {
                             when (e.key) {
-                                Key.DirectionUp -> { passwordFR.requestFocus(); true }
+                                Key.DirectionUp -> { quickConnectFR.requestFocus(); true }
                                 Key.DirectionLeft -> { quickConnectFR.requestFocus(); true }
                                 Key.DirectionRight -> { changeServerFR.requestFocus(); true }
                                 else -> false
@@ -338,7 +338,7 @@ fun LoginScreen(
                         } else false
                     }
                     .focusProperties {
-                        up = passwordFR
+                        up = quickConnectFR
                         left = quickConnectFR
                         right = changeServerFR
                     }

--- a/app/src/main/java/com/hritwik/avoid/presentation/ui/screen/auth/LoginScreen.kt
+++ b/app/src/main/java/com/hritwik/avoid/presentation/ui/screen/auth/LoginScreen.kt
@@ -243,7 +243,7 @@ fun LoginScreen(
                                         when (e.key) {
                                             Key.DirectionDown -> { signInFR.requestFocus(); true }
                                             Key.DirectionRight -> { changeServerFR.requestFocus(); true }
-                                            Key.DirectionUp -> true
+                                            Key.DirectionUp -> { passwordFR.requestFocus(); true }
                                             else -> false
                                         }
                                     } else false
@@ -251,7 +251,7 @@ fun LoginScreen(
                                 .focusProperties {
                                     down = signInFR
                                     right = changeServerFR
-                                    up = quickConnectFR
+                                    up = passwordFR
                                 }
                                 .focusable(),
                             shape = ButtonDefaults.outlinedShape,
@@ -277,7 +277,7 @@ fun LoginScreen(
                                             Key.DirectionDown -> { signInFR.requestFocus(); true }
                                             Key.DirectionLeft -> { quickConnectFR.requestFocus(); true }
                                             Key.DirectionRight -> { signInFR.requestFocus(); true }
-                                            Key.DirectionUp -> true
+                                            Key.DirectionUp -> { passwordFR.requestFocus(); true }
                                             else -> false
                                         }
                                     } else false
@@ -286,7 +286,7 @@ fun LoginScreen(
                                     down = signInFR
                                     left = quickConnectFR
                                     right = signInFR
-                                    up = changeServerFR
+                                    up = passwordFR
                                 }
                                 .focusable(),
                             shape = ButtonDefaults.outlinedShape,

--- a/app/src/main/java/com/hritwik/avoid/presentation/ui/screen/auth/QuickConnectAuthorizeScreen.kt
+++ b/app/src/main/java/com/hritwik/avoid/presentation/ui/screen/auth/QuickConnectAuthorizeScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
@@ -208,12 +209,27 @@ fun QuickConnectAuthorizeScreen(
                     .wrapContentSize()
                     .align(Alignment.BottomEnd)
                     .focusRequester(cancelButtonFocusRequester)
+                    .focusProperties {
+                        up = cancelButtonFocusRequester
+                        down = cancelButtonFocusRequester
+                        left = cancelButtonFocusRequester
+                        right = cancelButtonFocusRequester
+                    }
                     .focusable()
                     .onPreviewKeyEvent {
-                        if (it.key == Key.Back && it.type == KeyEventType.KeyDown) {
-                            viewModel.resetQuickConnectState()
-                            onCancel()
-                            true
+                        if (it.type == KeyEventType.KeyDown) {
+                            when (it.key) {
+                                Key.Back -> {
+                                    viewModel.resetQuickConnectState()
+                                    onCancel()
+                                    true
+                                }
+                                Key.DirectionUp,
+                                Key.DirectionDown,
+                                Key.DirectionLeft,
+                                Key.DirectionRight -> true
+                                else -> false
+                            }
                         } else {
                             false
                         }

--- a/app/src/main/java/com/hritwik/avoid/presentation/ui/screen/auth/QuickConnectScreen.kt
+++ b/app/src/main/java/com/hritwik/avoid/presentation/ui/screen/auth/QuickConnectScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.foundation.focusable
@@ -159,12 +160,27 @@ fun QuickConnectScreen(
                     .wrapContentSize()
                     .align(Alignment.BottomEnd)
                     .focusRequester(cancelButtonFocusRequester)
+                    .focusProperties {
+                        up = cancelButtonFocusRequester
+                        down = cancelButtonFocusRequester
+                        left = cancelButtonFocusRequester
+                        right = cancelButtonFocusRequester
+                    }
                     .focusable()
                     .onPreviewKeyEvent {
-                        if (it.key == Key.Back && it.type == KeyEventType.KeyDown) {
-                            viewModel.resetQuickConnectState()
-                            onCancel()
-                            true
+                        if (it.type == KeyEventType.KeyDown) {
+                            when (it.key) {
+                                Key.Back -> {
+                                    viewModel.resetQuickConnectState()
+                                    onCancel()
+                                    true
+                                }
+                                Key.DirectionUp,
+                                Key.DirectionDown,
+                                Key.DirectionLeft,
+                                Key.DirectionRight -> true
+                                else -> false
+                            }
                         } else {
                             false
                         }

--- a/app/src/main/java/com/hritwik/avoid/presentation/ui/screen/auth/ServerSetupScreen.kt
+++ b/app/src/main/java/com/hritwik/avoid/presentation/ui/screen/auth/ServerSetupScreen.kt
@@ -113,6 +113,7 @@ fun ServerSetupScreen(
         )
     }
     val textFieldFocusRequester = remember { FocusRequester() }
+    val certificateButtonFocusRequester = remember { FocusRequester() }
     val buttonFocusRequester = remember { FocusRequester() }
     var textFieldFocused by remember { mutableStateOf(false) }
     val connectButtonInteractionSource = remember { MutableInteractionSource() }
@@ -387,7 +388,10 @@ fun ServerSetupScreen(
                             .fillMaxWidth(0.92f)
                             .widthIn(max = 560.dp)
                             .focusRequester(textFieldFocusRequester)
-                            .focusProperties { next = buttonFocusRequester }
+                            .focusProperties {
+                                next = certificateButtonFocusRequester
+                                down = certificateButtonFocusRequester
+                            }
                             .onFocusChanged { focusState ->
                                 textFieldFocused = focusState.hasFocus
                                 if (focusState.hasFocus) {
@@ -494,7 +498,29 @@ fun ServerSetupScreen(
                             contentColor = Color.White
                         ),
                         modifier = Modifier
+                            .focusRequester(certificateButtonFocusRequester)
                             .pressToClick { handleCertificateClick() }
+                            .onPreviewKeyEvent { e ->
+                                if (e.type == KeyEventType.KeyDown) {
+                                    when (e.key) {
+                                        Key.DirectionDown -> {
+                                            buttonFocusRequester.requestFocus()
+                                            true
+                                        }
+                                        Key.DirectionUp -> {
+                                            textFieldFocusRequester.requestFocus()
+                                            true
+                                        }
+                                        else -> false
+                                    }
+                                } else {
+                                    false
+                                }
+                            }
+                            .focusProperties {
+                                down = buttonFocusRequester
+                                up = textFieldFocusRequester
+                            }
                             .focusable()
                     ) {
                         if (state.isMtlsImporting) {
@@ -558,8 +584,8 @@ fun ServerSetupScreen(
                     .focusRequester(buttonFocusRequester)
                     .pressToClick { handleConnect() }
                     .focusProperties {
-                        previous = textFieldFocusRequester
-                        up = textFieldFocusRequester
+                        previous = certificateButtonFocusRequester
+                        up = certificateButtonFocusRequester
                     }
                     .focusable(),
                 interactionSource = connectButtonInteractionSource,

--- a/app/src/main/java/com/hritwik/avoid/presentation/ui/screen/media/MediaDetailContent.kt
+++ b/app/src/main/java/com/hritwik/avoid/presentation/ui/screen/media/MediaDetailContent.kt
@@ -82,6 +82,7 @@ fun MediaDetailContent(
     episodes: List<MediaItem> = emptyList(),
     seasons: List<MediaItem> = emptyList(),
     specialFeatures: List<MediaItem> = emptyList(),
+    localTrailers: List<MediaItem> = emptyList(),
     initialSeasonId: String? = null,
     initialEpisodeIndex: Int = 0,
     shouldAutoFocusEpisode: Boolean = false,
@@ -669,15 +670,17 @@ fun MediaDetailContent(
 
             if(isMovie){
                 Spacer(modifier.height(calculateRoundedValue(20).sdp))
-
-                MediaActionButtons(
-                    modifier = Modifier.padding(horizontal = calculateRoundedValue(20).sdp),
-                    mediaItem = mediaItem,
-                    serverUrl = serverUrl,
-                    onPlayClick = onPlayClick,
-                    playButtonFocusRequester = playFocusRequester
-                )
             }
+
+            MediaActionButtons(
+                modifier = Modifier.padding(horizontal = calculateRoundedValue(20).sdp),
+                mediaItem = mediaItem,
+                serverUrl = serverUrl,
+                localTrailers = localTrailers,
+                onPlayClick = onPlayClick,
+                playButtonFocusRequester = playFocusRequester,
+                isMovie = isMovie
+            )
 
             LazyColumn (
                 modifier = modifier.fillMaxSize(),
@@ -700,8 +703,12 @@ fun MediaDetailContent(
                                     EpisodeThumbnailCard(
                                         modifier = Modifier.onPreviewKeyEvent { event ->
                                             if (event.type == KeyEventType.KeyDown && event.key == Key.DirectionUp) {
-                                                requestSelectedSeasonFocus()
-                                                true
+                                                if (showSeasonBar) {
+                                                    requestSelectedSeasonFocus()
+                                                    true
+                                                } else {
+                                                    false
+                                                }
                                             } else {
                                                 false
                                             }

--- a/app/src/main/java/com/hritwik/avoid/presentation/ui/screen/media/MediaDetailScreen.kt
+++ b/app/src/main/java/com/hritwik/avoid/presentation/ui/screen/media/MediaDetailScreen.kt
@@ -166,6 +166,7 @@ fun MediaDetailScreen(
                 episodes = episodes,
                 seasons = seasons,
                 specialFeatures = detailState.specialFeatures,
+                localTrailers = detailState.localTrailers,
                 initialSeasonId = initialSeasonId,
                 initialEpisodeIndex = initialEpisodeIndex,
                 shouldAutoFocusEpisode = episodeId != null,

--- a/app/src/main/java/com/hritwik/avoid/presentation/ui/state/MediaDetailState.kt
+++ b/app/src/main/java/com/hritwik/avoid/presentation/ui/state/MediaDetailState.kt
@@ -9,6 +9,7 @@ data class MediaDetailState(
     val mediaItem: MediaItem? = null,
     val similarItems: List<MediaItem> = emptyList(),
     val specialFeatures: List<MediaItem> = emptyList(),
+    val localTrailers: List<MediaItem> = emptyList(),
     val seasons: List<MediaItem>? = null,
     val episodes: List<MediaItem>? = null,
     val nextUpEpisode: MediaItem? = null,

--- a/app/src/main/java/com/hritwik/avoid/presentation/viewmodel/media/MediaViewModel.kt
+++ b/app/src/main/java/com/hritwik/avoid/presentation/viewmodel/media/MediaViewModel.kt
@@ -160,7 +160,8 @@ class MediaViewModel @Inject constructor(
             is NetworkResult.Success -> {
                 _state.value = _state.value.copy(
                     similarItems = result.data.similar,
-                    specialFeatures = result.data.special
+                    specialFeatures = result.data.special,
+                    localTrailers = result.data.localTrailers
                 )
             }
             else -> {  }


### PR DESCRIPTION
## Summary
- add Jellyfin local trailer fetching via `Items/{itemId}/LocalTrailers` and thread trailer data through repository, viewmodel, and detail state
- add a `Trailer` action to media detail actions and support trailer playback for movies, series, and seasons using the internal player
- harden TV remote navigation and make trailer loading best-effort so failures do not block similar/special resources

Closes #9