### PR TITLE
Default sorting

### DIFF
--- a/app/src/main/java/com/hritwik/avoid/data/remote/JellyfinApiService.kt
+++ b/app/src/main/java/com/hritwik/avoid/data/remote/JellyfinApiService.kt
@@ -125,6 +125,26 @@ interface JellyfinApiService {
         @Header("X-Emby-Authorization") authorization: String
     ): LibraryResponse
 
+    @GET("Shows/{seriesId}/Episodes")
+    suspend fun getEpisodes(
+        @Path("seriesId") seriesId: String,
+        @Query("userId") userId: String,
+        @Query("Fields") fields: String? = null,
+        @Query("Season") season: Int? = null,
+        @Query("SeasonId") seasonId: String? = null,
+        @Query("isMissing") isMissing: Boolean? = null,
+        @Query("adjacentTo") adjacentTo: String? = null,
+        @Query("startItemId") startItemId: String? = null,
+        @Query("StartIndex") startIndex: Int = 0,
+        @Query("Limit") limit: Int = 50000,
+        @Query("EnableImages") enableImages: Boolean = true,
+        @Query("ImageTypeLimit") imageTypeLimit: Int? = null,
+        @Query("EnableImageTypes") enableImageTypes: String? = "Primary",
+        @Query("EnableUserData") enableUserData: Boolean? = null,
+        @Query("sortBy") sortBy: String = "Default",
+        @Header("X-Emby-Authorization") authorization: String
+    ): LibraryResponse
+
     @GET("Items/{itemId}/Credits")
     suspend fun getItemCredits(
         @Path("itemId") itemId: String,

--- a/app/src/main/java/com/hritwik/avoid/data/repository/LibraryRepositoryImpl.kt
+++ b/app/src/main/java/com/hritwik/avoid/data/repository/LibraryRepositoryImpl.kt
@@ -2067,7 +2067,37 @@ class LibraryRepositoryImpl @Inject constructor(
 
             response.items.map { dto ->
                 mapToMediaItem(dto)
-            }.sortedBy { it.indexNumber ?: Int.MAX_VALUE }
+            }
+        }
+    }
+
+    override suspend fun getSiblingEpisodes(
+        userId: String,
+        seriesId: String,
+        episodeId: String,
+        accessToken: String
+    ): NetworkResult<List<MediaItem>> {
+        val serverUrl = getServerUrl()
+        return safeApiCall(serverUrl) {
+            val apiService = createApiService(serverUrl)
+
+            val authHeader = JellyfinApiService.createAuthHeader(deviceId, token = accessToken)
+            val response = apiService.getEpisodes(
+                seriesId = seriesId,
+                userId = userId,
+                adjacentTo = episodeId,
+                startIndex = 0,
+                limit = Int.MAX_VALUE,
+                isMissing = false,
+                sortBy = "Default",
+                fields = ApiConstants.FIELDS_BASIC,
+                enableImageTypes = DEFAULT_MEDIA_IMAGE_TYPES,
+                authorization = authHeader
+            )
+
+            response.items.map { dto ->
+                mapToMediaItem(dto)
+            }
         }
     }
 

--- a/app/src/main/java/com/hritwik/avoid/data/repository/LibraryRepositoryImpl.kt
+++ b/app/src/main/java/com/hritwik/avoid/data/repository/LibraryRepositoryImpl.kt
@@ -2058,7 +2058,7 @@ class LibraryRepositoryImpl @Inject constructor(
                 recursive = false,  
                 startIndex = 0,
                 limit = Int.MAX_VALUE,
-                sortBy = "SortName",
+                sortBy = "Default",
                 sortOrder = "Ascending",
                 fields = ApiConstants.FIELDS_BASIC,
                 enableImageTypes = DEFAULT_MEDIA_IMAGE_TYPES,

--- a/app/src/main/java/com/hritwik/avoid/domain/repository/LibraryRepository.kt
+++ b/app/src/main/java/com/hritwik/avoid/domain/repository/LibraryRepository.kt
@@ -322,6 +322,12 @@ interface LibraryRepository {
         seasonId: String,
         accessToken: String
     ): NetworkResult<List<MediaItem>>
+    suspend fun getSiblingEpisodes(
+        userId: String,
+        seriesId: String,
+        episodeId: String,
+        accessToken: String
+    ): NetworkResult<List<MediaItem>>
     suspend fun getNextUpEpisodes(
         userId: String,
         accessToken: String,

--- a/app/src/main/java/com/hritwik/avoid/presentation/viewmodel/media/MediaViewModel.kt
+++ b/app/src/main/java/com/hritwik/avoid/presentation/viewmodel/media/MediaViewModel.kt
@@ -205,8 +205,7 @@ class MediaViewModel @Inject constructor(
             )
         }) {
             is NetworkResult.Success -> {
-                val sorted = result.data.sortedBy { it.indexNumber ?: Int.MAX_VALUE }
-                _state.value = _state.value.copy(episodes = sorted)
+                _state.value = _state.value.copy(episodes = result.data)
             }
             else -> {  }
         }

--- a/app/src/main/java/com/hritwik/avoid/presentation/viewmodel/player/VideoPlaybackViewModel.kt
+++ b/app/src/main/java/com/hritwik/avoid/presentation/viewmodel/player/VideoPlaybackViewModel.kt
@@ -1057,7 +1057,7 @@ class VideoPlaybackViewModel @Inject constructor(
             return
         }
 
-        when (val episodesResult = libraryRepository.getEpisodes(userId, seasonId, accessToken)) {
+        when (val episodesResult = libraryRepository.getSiblingEpisodes(userId, mediaItem.seriesId, mediaItem.id, accessToken)) {
             is NetworkResult.Success -> {
                 val episodes = episodesResult.data
                 val resolvedEpisodes = episodes.map { episode ->
@@ -1070,15 +1070,10 @@ class VideoPlaybackViewModel @Inject constructor(
                 )
             }
             else -> {
-                val existingIndex = _state.value.siblingEpisodes.indexOfFirst { it.id == mediaItem.id }
-                if (existingIndex != -1) {
-                    _state.value = _state.value.copy(currentEpisodeIndex = existingIndex)
-                } else {
-                    _state.value = _state.value.copy(
-                        siblingEpisodes = emptyList(),
-                        currentEpisodeIndex = -1
-                    )
-                }
+                _state.value = _state.value.copy(
+                    siblingEpisodes = emptyList(),
+                    currentEpisodeIndex = -1
+                )
             }
         }
     }


### PR DESCRIPTION
use jellyfin's default sorting
as for shows with special episodes (e.g. simpsons on TVDB) the specials get inserted into the season. => sorting only by Episode number does not work then.

at first i only changed the sorting on the request and removed the additional sorting in the ui.
however play_next and play_prev were still showing incorrect behaviour because next_episode on specials still showed the next special episode and not the next actual episode.
Example:
S01E01 -> S01E02 -> S00E01 -> S00E02
But the order should have been:
S01E01 -> S01E02 -> S00E01 -> S01E03

To fix this i implemented  [this api call](https://api.jellyfin.org/#tag/TvShows/operation/GetEpisodes).
Has the additional benefit that next_episode also work from S01 last episode -> S02E01