### PR TITLE
Add configurable controls timeout setting

### DIFF
--- a/app/src/main/java/com/hritwik/avoid/data/local/PreferencesManager.kt
+++ b/app/src/main/java/com/hritwik/avoid/data/local/PreferencesManager.kt
@@ -138,6 +138,7 @@ class PreferencesManager @Inject constructor(
             booleanPreferencesKey(PreferenceConstants.KEY_FRAME_RATE_SWITCH_ENABLED)
         private val PREFER_HDR_OVER_DV = booleanPreferencesKey(PreferenceConstants.KEY_PREFER_HDR_OVER_DV)
         private val HDR_FORMAT_PREFERENCE = stringPreferencesKey(PreferenceConstants.KEY_HDR_FORMAT_PREFERENCE)
+        private val CONTROLS_TIMEOUT_SECONDS = intPreferencesKey(PreferenceConstants.KEY_CONTROLS_TIMEOUT_SECONDS)
 
         private const val TINK_KEYSET_PREF = "void_tink_keyset"
         private const val TINK_KEYSET_NAME = "tink_keyset"
@@ -783,6 +784,10 @@ class PreferencesManager @Inject constructor(
         HdrFormatPreference.fromValue(raw)
     }
 
+    fun getControlsTimeoutSeconds(): Flow<Int> = dataStore.data.map { preferences ->
+        preferences[CONTROLS_TIMEOUT_SECONDS] ?: PreferenceConstants.DEFAULT_CONTROLS_TIMEOUT_SECONDS
+    }
+
     
 
     fun getImageCacheSize(): Flow<Long> = dataStore.data.map { preferences ->
@@ -987,6 +992,12 @@ class PreferencesManager @Inject constructor(
     suspend fun saveHdrFormatPreference(preference: HdrFormatPreference) {
         dataStore.edit { preferences ->
             preferences[HDR_FORMAT_PREFERENCE] = preference.value
+        }
+    }
+
+    suspend fun saveControlsTimeoutSeconds(seconds: Int) {
+        dataStore.edit { preferences ->
+            preferences[CONTROLS_TIMEOUT_SECONDS] = seconds
         }
     }
 

--- a/app/src/main/java/com/hritwik/avoid/presentation/ui/components/dialogs/ControlsTimeoutDialog.kt
+++ b/app/src/main/java/com/hritwik/avoid/presentation/ui/components/dialogs/ControlsTimeoutDialog.kt
@@ -1,0 +1,154 @@
+package com.hritwik.avoid.presentation.ui.components.dialogs
+
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Slider
+import androidx.compose.material.SliderDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import com.hritwik.avoid.utils.helpers.calculateRoundedValue
+import ir.kaaveh.sdpcompose.sdp
+import kotlin.math.roundToInt
+
+@Composable
+fun ControlsTimeoutDialog(
+    currentSeconds: Int,
+    onSecondsSelected: (Int) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val minValue = 1
+    val maxValue = 30
+    val initialValue = currentSeconds.coerceIn(minValue, maxValue)
+    var sliderValue by remember { mutableFloatStateOf(initialValue.toFloat()) }
+    val sliderFocusRequester = remember { FocusRequester() }
+    var sliderHasFocus by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        sliderFocusRequester.requestFocus()
+    }
+
+    fun formatSeconds(value: Int): String {
+        val seconds = value / 2.0f
+        return if (seconds == seconds.toLong().toFloat()) {
+            "${seconds.toInt()}s"
+        } else {
+            String.format("%.1fs", seconds)
+        }
+    }
+
+    fun sliderToSeconds(sliderValue: Float): Int {
+        return sliderValue.roundToInt()
+    }
+
+    SelectionDialog(
+        title = "Controls Timeout",
+        onDismiss = onDismiss
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(calculateRoundedValue(16).sdp)
+        ) {
+            val displaySeconds = sliderToSeconds(sliderValue) / 2.0f
+            val displayText = if (displaySeconds == 5.0f) {
+                "5.0s (Default)"
+            } else if (displaySeconds == displaySeconds.toLong().toFloat()) {
+                "${displaySeconds.toInt()}s"
+            } else {
+                String.format("%.1fs", displaySeconds)
+            }
+
+            Text(
+                text = displayText,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Medium,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Slider(
+                value = sliderValue,
+                onValueChange = { value ->
+                    sliderValue = value.coerceIn(minValue.toFloat(), maxValue.toFloat())
+                },
+                valueRange = minValue.toFloat()..maxValue.toFloat(),
+                steps = maxValue - minValue - 1,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = calculateRoundedValue(4).sdp)
+                    .focusRequester(sliderFocusRequester)
+                    .onFocusChanged { focusState ->
+                        sliderHasFocus = focusState.hasFocus
+                    }
+                    .focusable()
+                    .onPreviewKeyEvent { event ->
+                        if (event.type != KeyEventType.KeyDown) {
+                            return@onPreviewKeyEvent false
+                        }
+
+                        when (event.key) {
+                            Key.DirectionLeft -> {
+                                if (!sliderHasFocus) {
+                                    sliderFocusRequester.requestFocus()
+                                }
+                                sliderValue = (sliderValue - 1).coerceIn(minValue.toFloat(), maxValue.toFloat())
+                                true
+                            }
+
+                            Key.DirectionRight -> {
+                                if (!sliderHasFocus) {
+                                    sliderFocusRequester.requestFocus()
+                                }
+                                sliderValue = (sliderValue + 1).coerceIn(minValue.toFloat(), maxValue.toFloat())
+                                true
+                            }
+
+                            Key.DirectionCenter, Key.Enter, Key.NumPadEnter -> {
+                                if (!sliderHasFocus) {
+                                    sliderFocusRequester.requestFocus()
+                                    return@onPreviewKeyEvent true
+                                }
+
+                                onSecondsSelected(sliderToSeconds(sliderValue))
+                                onDismiss()
+                                true
+                            }
+
+                            else -> false
+                        }
+                    },
+                colors = SliderDefaults.colors(
+                    thumbColor = MaterialTheme.colorScheme.primary,
+                    activeTrackColor = MaterialTheme.colorScheme.primary,
+                    inactiveTrackColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+                )
+            )
+
+            Text(
+                text = "Use left/right to adjust, press OK to confirm",
+                style = MaterialTheme.typography.bodySmall,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/hritwik/avoid/presentation/ui/components/dialogs/ControlsTimeoutDialog.kt
+++ b/app/src/main/java/com/hritwik/avoid/presentation/ui/components/dialogs/ControlsTimeoutDialog.kt
@@ -39,7 +39,7 @@ fun ControlsTimeoutDialog(
 ) {
     val minValue = 1
     val maxValue = 30
-    val initialValue = currentSeconds.coerceIn(minValue, maxValue)
+    val initialValue = (currentSeconds * 2).coerceIn(minValue, maxValue)
     var sliderValue by remember { mutableFloatStateOf(initialValue.toFloat()) }
     val sliderFocusRequester = remember { FocusRequester() }
     var sliderHasFocus by remember { mutableStateOf(false) }
@@ -58,7 +58,7 @@ fun ControlsTimeoutDialog(
     }
 
     fun sliderToSeconds(sliderValue: Float): Int {
-        return sliderValue.roundToInt()
+        return (sliderValue / 2).roundToInt()
     }
 
     SelectionDialog(

--- a/app/src/main/java/com/hritwik/avoid/presentation/ui/screen/player/ExoPlayerView.kt
+++ b/app/src/main/java/com/hritwik/avoid/presentation/ui/screen/player/ExoPlayerView.kt
@@ -147,6 +147,7 @@ fun ExoPlayerView(
     audioPassthroughEnabled: Boolean,
     hdrFormatPreference: HdrFormatPreference,
     gesturesEnabled: Boolean,
+    controlsTimeoutMs: Long = 5000L,
     onBackClick: () -> Unit,
     viewModel: VideoPlaybackViewModel,
     userDataViewModel: UserDataViewModel
@@ -1218,7 +1219,8 @@ fun ExoPlayerView(
                     null
                 },
                 videoQualityLabel = playerState.playbackTranscodeOption.label,
-                onVideoClick = { viewModel.showVideoQualityDialog() }
+                onVideoClick = { viewModel.showVideoQualityDialog() },
+                controlsTimeoutMs = controlsTimeoutMs
             )
 
 

--- a/app/src/main/java/com/hritwik/avoid/presentation/ui/screen/player/MPVPlayerView.kt
+++ b/app/src/main/java/com/hritwik/avoid/presentation/ui/screen/player/MPVPlayerView.kt
@@ -109,6 +109,7 @@ fun MpvPlayerView(
     serverUrl: String,
     autoSkipSegments: Boolean,
     gesturesEnabled: Boolean,
+    controlsTimeoutMs: Long = 5000L,
     onBackClick: () -> Unit,
     videoPlaybackViewModel: VideoPlaybackViewModel,
     userDataViewModel: UserDataViewModel
@@ -1047,7 +1048,8 @@ fun MpvPlayerView(
             onSubtitleClick = { showSubtitleDialog = true },
             onSubtitleOptionsClick = { showSubtitleMenu = true },
             videoQualityLabel = playerState.playbackTranscodeOption.label,
-            onVideoClick = { videoPlaybackViewModel.showVideoQualityDialog() }
+            onVideoClick = { videoPlaybackViewModel.showVideoQualityDialog() },
+            controlsTimeoutMs = controlsTimeoutMs
         )
 
 

--- a/app/src/main/java/com/hritwik/avoid/presentation/ui/screen/player/VideoControlsOverlay.kt
+++ b/app/src/main/java/com/hritwik/avoid/presentation/ui/screen/player/VideoControlsOverlay.kt
@@ -116,6 +116,7 @@ fun VideoControlsOverlay(
     onVideoClick: (() -> Unit)? = null,
     progressBarColor: Color = Minsk,
     seekProgressColor: Color? = null,
+    controlsTimeoutMs: Long = 5000L,
 ) {
     val overlayFocusRequester = remember { FocusRequester() }
     val previousEpisodeFocusRequester = remember { FocusRequester() }
@@ -214,7 +215,7 @@ fun VideoControlsOverlay(
             while (true) {
                 delay(1000)
                 val currentTime = System.currentTimeMillis()
-                if (currentTime - lastInteractionTime >= 5000) {
+                if (currentTime - lastInteractionTime >= controlsTimeoutMs) {
                     onDismissControls()
                     break
                 }

--- a/app/src/main/java/com/hritwik/avoid/presentation/ui/screen/player/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/hritwik/avoid/presentation/ui/screen/player/VideoPlayerScreen.kt
@@ -56,6 +56,7 @@ fun VideoPlayerScreen(
     val frameRateSwitchEnabled = playbackSettings.frameRateSwitchEnabled
     val hdrFormatPreference = playbackSettings.hdrFormatPreference
     val autoSkipSegments = playbackSettings.autoSkipSegments
+    val controlsTimeoutSeconds = playbackSettings.controlsTimeoutSeconds
     val personalization by userDataViewModel.personalizationSettings.collectAsStateWithLifecycle()
     val gesturesEnabled = personalization.gesturesEnabled
     val userId = authState.authSession?.userId?.id ?: ""
@@ -124,6 +125,7 @@ fun VideoPlayerScreen(
                 serverUrl = serverUrl,
                 autoSkipSegments = autoSkipSegments,
                 gesturesEnabled = gesturesEnabled,
+                controlsTimeoutMs = controlsTimeoutSeconds * 1000L,
                 onBackClick = onBackClick,
                 videoPlaybackViewModel = viewModel,
                 userDataViewModel = userDataViewModel
@@ -143,6 +145,7 @@ fun VideoPlayerScreen(
                 frameRateSwitchEnabled = frameRateSwitchEnabled,
                 hdrFormatPreference = hdrFormatPreference,
                 gesturesEnabled = gesturesEnabled,
+                controlsTimeoutMs = controlsTimeoutSeconds * 1000L,
                 onBackClick = onBackClick,
                 decoderMode = decoderMode,
                 viewModel = viewModel,

--- a/app/src/main/java/com/hritwik/avoid/presentation/ui/screen/profile/VoidTabContent.kt
+++ b/app/src/main/java/com/hritwik/avoid/presentation/ui/screen/profile/VoidTabContent.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SurroundSound
 import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material.icons.filled.TextFields
+import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -43,6 +44,7 @@ import com.hritwik.avoid.presentation.ui.components.common.SettingItemWithSwitch
 import com.hritwik.avoid.presentation.ui.components.dialogs.DeviceInfoDialog
 import com.hritwik.avoid.presentation.ui.components.dialogs.DisplayModeSelectionDialog
 import com.hritwik.avoid.presentation.ui.components.dialogs.HdrFormatSelectionDialog
+import com.hritwik.avoid.presentation.ui.components.dialogs.ControlsTimeoutDialog
 import com.hritwik.avoid.presentation.ui.components.dialogs.MpvConfigDialog
 import com.hritwik.avoid.presentation.ui.components.dialogs.PlayerSelectionDialog
 import com.hritwik.avoid.presentation.ui.components.dialogs.PlayerProgressColorDialog
@@ -73,6 +75,7 @@ fun VoidTabContent(
     val externalPlayerEnabled = playbackSettings.externalPlayerEnabled
     val directPlayEnabled = playbackSettings.directPlayEnabled
     val hdrFormatPreference = playbackSettings.hdrFormatPreference
+    val controlsTimeoutSeconds = playbackSettings.controlsTimeoutSeconds
     val mpvConfig by userDataViewModel.mpvConfig.collectAsStateWithLifecycle()
     val subtitleSize by userDataViewModel.subtitleSize.collectAsStateWithLifecycle()
     val progressBarColorKey by userDataViewModel.playerProgressColor.collectAsStateWithLifecycle()
@@ -290,6 +293,29 @@ fun VoidTabContent(
                 checked = frameRateSwitchEnabled,
                 onCheckedChange = { userDataViewModel.setFrameRateSwitchEnabled(it) }
             )
+        }
+
+        item {
+            var showControlsTimeoutDialog by remember { mutableStateOf(false) }
+
+            SettingItem(
+                icon = Icons.Default.Timer,
+                title = "Controls Timeout",
+                subtitle = "How long on-screen controls stay visible",
+                onClick = { showControlsTimeoutDialog = true },
+                trailingText = "${controlsTimeoutSeconds}s"
+            )
+
+            if (showControlsTimeoutDialog) {
+                ControlsTimeoutDialog(
+                    currentSeconds = controlsTimeoutSeconds,
+                    onSecondsSelected = { seconds ->
+                        userDataViewModel.setControlsTimeoutSeconds(seconds)
+                        showControlsTimeoutDialog = false
+                    },
+                    onDismiss = { showControlsTimeoutDialog = false }
+                )
+            }
         }
 
         item {

--- a/app/src/main/java/com/hritwik/avoid/presentation/viewmodel/user/UserDataViewModel.kt
+++ b/app/src/main/java/com/hritwik/avoid/presentation/viewmodel/user/UserDataViewModel.kt
@@ -70,7 +70,8 @@ class UserDataViewModel @Inject constructor(
         val externalPlayerEnabled: Boolean,
         val playerType: PlayerType,
         val directPlayEnabled: Boolean,
-        val hdrFormatPreference: HdrFormatPreference
+        val hdrFormatPreference: HdrFormatPreference,
+        val controlsTimeoutSeconds: Int
     )
 
     private data class PlaybackSettingsBundle(
@@ -85,6 +86,7 @@ class UserDataViewModel @Inject constructor(
         val externalPlayerEnabled: Boolean = PreferenceConstants.DEFAULT_EXTERNAL_PLAYER_ENABLED,
         val directPlayEnabled: Boolean = PreferenceConstants.DEFAULT_DIRECT_PLAY_ENABLED,
         val hdrFormatPreference: HdrFormatPreference = HdrFormatPreference.AUTO,
+        val controlsTimeoutSeconds: Int = PreferenceConstants.DEFAULT_CONTROLS_TIMEOUT_SECONDS
     )
 
     init {
@@ -152,11 +154,15 @@ class UserDataViewModel @Inject constructor(
                     externalPlayerEnabled = bundle.externalPlayerEnabled,
                     playerType = player,
                     directPlayEnabled = bundle.directPlayEnabled,
-                    hdrFormatPreference = bundle.hdrFormatPreference
+                    hdrFormatPreference = bundle.hdrFormatPreference,
+                    controlsTimeoutSeconds = bundle.controlsTimeoutSeconds
                 )
             }
             .combine(preferencesManager.getDirectPlayEnabled()) { settings, directPlay ->
                 settings.copy(directPlayEnabled = directPlay)
+            }
+            .combine(preferencesManager.getControlsTimeoutSeconds()) { settings, timeout ->
+                settings.copy(controlsTimeoutSeconds = timeout)
             }
             .stateIn(
                 viewModelScope,
@@ -173,7 +179,8 @@ class UserDataViewModel @Inject constructor(
                     PreferenceConstants.DEFAULT_EXTERNAL_PLAYER_ENABLED,
                     PlayerType.fromValue(PreferenceConstants.DEFAULT_PLAYER_TYPE),
                     PreferenceConstants.DEFAULT_DIRECT_PLAY_ENABLED,
-                    HdrFormatPreference.fromValue(PreferenceConstants.DEFAULT_HDR_FORMAT_PREFERENCE)
+                    HdrFormatPreference.fromValue(PreferenceConstants.DEFAULT_HDR_FORMAT_PREFERENCE),
+                    PreferenceConstants.DEFAULT_CONTROLS_TIMEOUT_SECONDS
                 )
             )
 
@@ -300,6 +307,10 @@ class UserDataViewModel @Inject constructor(
 
     fun setHdrFormatPreference(preference: HdrFormatPreference) {
         viewModelScope.launch { preferencesManager.saveHdrFormatPreference(preference) }
+    }
+
+    fun setControlsTimeoutSeconds(seconds: Int) {
+        viewModelScope.launch { preferencesManager.saveControlsTimeoutSeconds(seconds) }
     }
 
     fun setSubtitleSize(size: String) {

--- a/app/src/main/java/com/hritwik/avoid/utils/constants/PreferenceConstants.kt
+++ b/app/src/main/java/com/hritwik/avoid/utils/constants/PreferenceConstants.kt
@@ -77,6 +77,7 @@ object PreferenceConstants {
     const val KEY_PREFER_HDR_OVER_DV = "prefer_hdr_over_dolby_vision"
     const val KEY_HDR_FORMAT_PREFERENCE = "hdr_format_preference"
     const val KEY_FRAME_RATE_SWITCH_ENABLED = "frame_rate_switch_enabled"
+    const val KEY_CONTROLS_TIMEOUT_SECONDS = "controls_timeout_seconds"
 
     const val KEY_LIBRARY_VIEW_TYPE = "library_view_type"
     const val KEY_LIBRARY_SORT_ORDER = "library_sort_order"
@@ -150,6 +151,7 @@ object PreferenceConstants {
     const val DEFAULT_PREFER_HDR_OVER_DV = false
     const val DEFAULT_HDR_FORMAT_PREFERENCE = "auto"
     const val DEFAULT_FRAME_RATE_SWITCH_ENABLED = false
+    const val DEFAULT_CONTROLS_TIMEOUT_SECONDS = 5
     const val DEFAULT_SERVER_LEGACY_PLAYBACK = false
     const val DEFAULT_REMEMBER_ACCOUNT = true
 


### PR DESCRIPTION
## Summary
- Adds user-configurable timeout for video player on-screen controls
- Replaces hardcoded 5 second timeout with a setting adjustable from 0.5s to 15s
- Uses half-second increments via a slider dialog in Void Settings

## Changes
- Added `KEY_CONTROLS_TIMEOUT_SECONDS` preference constant with default of 5 seconds
- Added getter/setter methods in `PreferencesManager`
- Added `controlsTimeoutSeconds` to `PlaybackSettings` data class
- Updated `VideoControlsOverlay` to accept timeout parameter
- Updated `MPVPlayerView` and `ExoPlayerView` to pass timeout to overlay
- Updated `VideoPlayerScreen` to extract and pass the setting
- Added UI setting item in `VoidTabContent` under Playback Settings
- Created new `ControlsTimeoutDialog` using slider pattern

## Testing
- Slider allows selection from 0.5s to 15s in half-second increments
- Default value is 5 seconds
- Setting persists across app restarts

Fixes #15