### PR TITLE
Add hide watched setting to filter library items

### DIFF
--- a/app/src/main/java/com/hritwik/avoid/data/local/PreferencesManager.kt
+++ b/app/src/main/java/com/hritwik/avoid/data/local/PreferencesManager.kt
@@ -138,6 +138,8 @@ class PreferencesManager @Inject constructor(
             booleanPreferencesKey(PreferenceConstants.KEY_FRAME_RATE_SWITCH_ENABLED)
         private val PREFER_HDR_OVER_DV = booleanPreferencesKey(PreferenceConstants.KEY_PREFER_HDR_OVER_DV)
         private val HDR_FORMAT_PREFERENCE = stringPreferencesKey(PreferenceConstants.KEY_HDR_FORMAT_PREFERENCE)
+        private val CONTROLS_TIMEOUT_SECONDS = intPreferencesKey(PreferenceConstants.KEY_CONTROLS_TIMEOUT_SECONDS)
+        private val LIBRARY_FILTER_WATCHED = booleanPreferencesKey(PreferenceConstants.KEY_LIBRARY_FILTER_WATCHED)
 
         private const val TINK_KEYSET_PREF = "void_tink_keyset"
         private const val TINK_KEYSET_NAME = "tink_keyset"
@@ -783,6 +785,14 @@ class PreferencesManager @Inject constructor(
         HdrFormatPreference.fromValue(raw)
     }
 
+    fun getControlsTimeoutSeconds(): Flow<Int> = dataStore.data.map { preferences ->
+        preferences[CONTROLS_TIMEOUT_SECONDS] ?: PreferenceConstants.DEFAULT_CONTROLS_TIMEOUT_SECONDS
+    }
+
+    fun getLibraryFilterWatched(): Flow<Boolean> = dataStore.data.map { preferences ->
+        preferences[LIBRARY_FILTER_WATCHED] ?: PreferenceConstants.DEFAULT_LIBRARY_FILTER_WATCHED
+    }
+
     
 
     fun getImageCacheSize(): Flow<Long> = dataStore.data.map { preferences ->
@@ -987,6 +997,18 @@ class PreferencesManager @Inject constructor(
     suspend fun saveHdrFormatPreference(preference: HdrFormatPreference) {
         dataStore.edit { preferences ->
             preferences[HDR_FORMAT_PREFERENCE] = preference.value
+        }
+    }
+
+    suspend fun saveControlsTimeoutSeconds(seconds: Int) {
+        dataStore.edit { preferences ->
+            preferences[CONTROLS_TIMEOUT_SECONDS] = seconds
+        }
+    }
+
+    suspend fun saveLibraryFilterWatched(hideWatched: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[LIBRARY_FILTER_WATCHED] = hideWatched
         }
     }
 

--- a/app/src/main/java/com/hritwik/avoid/data/remote/JellyfinApiService.kt
+++ b/app/src/main/java/com/hritwik/avoid/data/remote/JellyfinApiService.kt
@@ -117,6 +117,7 @@ interface JellyfinApiService {
         @Query("SortOrder") sortOrder: String = "Ascending",
         @Query("Genres") genres: String? = null,
         @Query("Studios") studios: String? = null,
+        @Query("IsPlayed") isPlayed: Boolean? = null,
         @Query("Fields") fields: String? = null,  
         @Query("EnableImageTypes") enableImageTypes: String? = "Primary",  
         @Query("EnableImages") enableImages: Boolean = true,

--- a/app/src/main/java/com/hritwik/avoid/data/repository/LibraryRepositoryImpl.kt
+++ b/app/src/main/java/com/hritwik/avoid/data/repository/LibraryRepositoryImpl.kt
@@ -178,7 +178,8 @@ class LibraryRepositoryImpl @Inject constructor(
         enableImages: Boolean,
         enableUserData: Boolean,
         enableImageTypes: String?,
-        fields: String?
+        fields: String?,
+        isPlayed: Boolean?
     ): NetworkResult<List<MediaItem>> {
         
         
@@ -203,6 +204,7 @@ class LibraryRepositoryImpl @Inject constructor(
                 sortOrder = sortOrder.toApiValue(),
                 genres = genre,
                 studios = studio,
+                isPlayed = isPlayed,
                 fields = fields ?: ApiConstants.FIELDS_MINIMAL,
                 enableImageTypes = enableImageTypes ?: ApiConstants.IMAGE_TYPE_PRIMARY,
                 enableImages = enableImages,

--- a/app/src/main/java/com/hritwik/avoid/domain/repository/LibraryRepository.kt
+++ b/app/src/main/java/com/hritwik/avoid/domain/repository/LibraryRepository.kt
@@ -43,7 +43,8 @@ interface LibraryRepository {
         enableImages: Boolean = true,
         enableUserData: Boolean = false,
         enableImageTypes: String? = ApiConstants.IMAGE_TYPE_PRIMARY,
-        fields: String? = ApiConstants.FIELDS_MINIMAL
+        fields: String? = ApiConstants.FIELDS_MINIMAL,
+        isPlayed: Boolean? = null
     ): NetworkResult<List<MediaItem>>
     suspend fun getLibraryGenres(
         userId: String,

--- a/app/src/main/java/com/hritwik/avoid/domain/usecase/library/GetLibraryItemsUseCase.kt
+++ b/app/src/main/java/com/hritwik/avoid/domain/usecase/library/GetLibraryItemsUseCase.kt
@@ -29,7 +29,8 @@ class GetLibraryItemsUseCase @Inject constructor(
         val enableImages: Boolean = true,
         val enableUserData: Boolean = false,
         val enableImageTypes: String? = ApiConstants.IMAGE_TYPE_PRIMARY,
-        val fields: String? = ApiConstants.FIELDS_MINIMAL
+        val fields: String? = ApiConstants.FIELDS_MINIMAL,
+        val isPlayed: Boolean? = null
     )
 
     override suspend fun execute(parameters: Params): NetworkResult<List<MediaItem>> {
@@ -48,7 +49,8 @@ class GetLibraryItemsUseCase @Inject constructor(
             enableImages = parameters.enableImages,
             enableUserData = parameters.enableUserData,
             enableImageTypes = parameters.enableImageTypes,
-            fields = parameters.fields
+            fields = parameters.fields,
+            isPlayed = parameters.isPlayed
         )
     }
 }

--- a/app/src/main/java/com/hritwik/avoid/presentation/ui/navigation/MediaNavGraph.kt
+++ b/app/src/main/java/com/hritwik/avoid/presentation/ui/navigation/MediaNavGraph.kt
@@ -26,6 +26,7 @@ import com.hritwik.avoid.presentation.ui.screen.shows.ShowsScreen
 import com.hritwik.avoid.presentation.viewmodel.auth.AuthServerViewModel
 import com.hritwik.avoid.presentation.viewmodel.library.LibraryViewModel
 import com.hritwik.avoid.presentation.viewmodel.media.MediaViewModel
+import com.hritwik.avoid.presentation.viewmodel.user.UserDataViewModel
 
 private const val LIBRARY_DETAIL_PRESERVE_CACHE_KEY = "libraryDetail_preserveCache"
 
@@ -33,6 +34,7 @@ fun NavGraphBuilder.mediaGraph(
     navController: NavHostController,
     authViewModel: AuthServerViewModel,
     libraryViewModel: LibraryViewModel,
+    userDataViewModel: UserDataViewModel,
     sideNavigationFocusRequester: FocusRequester
 ) {
     composable(Routes.LIBRARY) {
@@ -200,6 +202,8 @@ fun NavGraphBuilder.mediaGraph(
             .distinct()
         val shouldPreserveCache =
             backStackEntry.savedStateHandle.get<Boolean>(LIBRARY_DETAIL_PRESERVE_CACHE_KEY) == true
+        val playbackSettings by userDataViewModel.playbackSettings.collectAsStateWithLifecycle()
+        val hideWatched = playbackSettings.hideWatched
 
         LibraryScreen(
             libraryId = libraryId,
@@ -207,6 +211,7 @@ fun NavGraphBuilder.mediaGraph(
             studio = studioName,
             libraryIds = allLibraryIds,
             libraryType = libraryType,
+            hideWatched = hideWatched,
             onBackClick = { navController.navigateUp() },
             onMediaItemClick = { mediaItem: MediaItem ->
                 backStackEntry.savedStateHandle[LIBRARY_DETAIL_PRESERVE_CACHE_KEY] = true

--- a/app/src/main/java/com/hritwik/avoid/presentation/ui/navigation/VoidNavigation.kt
+++ b/app/src/main/java/com/hritwik/avoid/presentation/ui/navigation/VoidNavigation.kt
@@ -23,6 +23,7 @@ import com.hritwik.avoid.presentation.ui.state.InitializationState
 import com.hritwik.avoid.presentation.ui.state.NavigationState
 import com.hritwik.avoid.presentation.viewmodel.auth.AuthServerViewModel
 import com.hritwik.avoid.presentation.viewmodel.library.LibraryViewModel
+import com.hritwik.avoid.presentation.viewmodel.user.UserDataViewModel
 import kotlinx.coroutines.delay
 
 @Composable
@@ -32,6 +33,7 @@ fun VoidNavigation(navigator: Navigator = rememberNavigator()) {
     val authState by authViewModel.state.collectAsStateWithLifecycle()
     var navigationState by remember { mutableStateOf<NavigationState>(NavigationState.Loading) }
     val libraryViewModel: LibraryViewModel = hiltViewModel()
+    val userDataViewModel: UserDataViewModel = hiltViewModel()
     val startDestination = if (authState.isAuthenticated) Routes.HOME else Routes.SERVER_SETUP
     val backStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = backStackEntry?.destination?.route
@@ -107,7 +109,7 @@ fun VoidNavigation(navigator: Navigator = rememberNavigator()) {
             ) {
                 authGraph(navController, authViewModel)
                 homeGraph(navController, authViewModel, libraryViewModel, sideNavigationFocusRequester)
-                mediaGraph(navController, authViewModel, libraryViewModel, sideNavigationFocusRequester)
+                mediaGraph(navController, authViewModel, libraryViewModel, userDataViewModel, sideNavigationFocusRequester)
                 profileGraph(navController, authViewModel, sideNavigationFocusRequester)
             }
 

--- a/app/src/main/java/com/hritwik/avoid/presentation/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/com/hritwik/avoid/presentation/ui/screen/library/LibraryScreen.kt
@@ -45,6 +45,7 @@ fun LibraryScreen(
     studio: String? = null,
     libraryIds: List<String> = listOf(libraryId),
     libraryType: LibraryType? = null,
+    hideWatched: Boolean = false,
     onBackClick: () -> Unit = {},
     onMediaItemClick: (MediaItem) -> Unit = {},
     onMediaItemFocus: (MediaItem) -> Unit = {},
@@ -98,7 +99,7 @@ fun LibraryScreen(
 
     
     
-    LaunchedEffect(libraryId, authState.authSession, selectedSortOption, sortDirection, selectedGenre, studio, reloadTrigger) {
+    LaunchedEffect(libraryId, authState.authSession, selectedSortOption, sortDirection, selectedGenre, studio, reloadTrigger, hideWatched) {
         if (reloadTrigger == 0) return@LaunchedEffect
         authState.authSession?.let { session ->
                 libraryViewModel.loadLibraryItems(
@@ -111,7 +112,8 @@ fun LibraryScreen(
                     genre = selectedGenre,
                     studio = studio,
                     includeItemTypes = includeItemTypes,
-                    skipCacheRefresh = false
+                    skipCacheRefresh = false,
+                    isPlayed = if (hideWatched) false else null
                 )
             }
         }
@@ -170,7 +172,8 @@ fun LibraryScreen(
                 selectedGenre,
                 studio,
                 includeItemTypes,
-                pagerCacheVersion
+                pagerCacheVersion,
+                hideWatched
             ) {
                 libraryViewModel.libraryItemsPager(
                     userId = session.userId.id,
@@ -181,7 +184,8 @@ fun LibraryScreen(
                     sortOrder = sortDirection,
                     genre = selectedGenre,
                     studio = studio,
-                    includeItemTypes = includeItemTypes
+                    includeItemTypes = includeItemTypes,
+                    isPlayed = if (hideWatched) false else null
                 )
             }
             pager.collectAsLazyPagingItems()

--- a/app/src/main/java/com/hritwik/avoid/presentation/ui/screen/profile/VoidTabContent.kt
+++ b/app/src/main/java/com/hritwik/avoid/presentation/ui/screen/profile/VoidTabContent.kt
@@ -24,7 +24,9 @@ import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SurroundSound
 import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material.icons.filled.TextFields
+import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -73,6 +75,7 @@ fun VoidTabContent(
     val externalPlayerEnabled = playbackSettings.externalPlayerEnabled
     val directPlayEnabled = playbackSettings.directPlayEnabled
     val hdrFormatPreference = playbackSettings.hdrFormatPreference
+    val hideWatched = playbackSettings.hideWatched
     val mpvConfig by userDataViewModel.mpvConfig.collectAsStateWithLifecycle()
     val subtitleSize by userDataViewModel.subtitleSize.collectAsStateWithLifecycle()
     val progressBarColorKey by userDataViewModel.playerProgressColor.collectAsStateWithLifecycle()
@@ -289,6 +292,16 @@ fun VoidTabContent(
                 subtitle = "Switch display mode and refresh rate to match content",
                 checked = frameRateSwitchEnabled,
                 onCheckedChange = { userDataViewModel.setFrameRateSwitchEnabled(it) }
+            )
+        }
+
+        item {
+            SettingItemWithSwitch(
+                icon = Icons.Default.VisibilityOff,
+                title = "Hide Watched",
+                subtitle = "Hide items you've already watched from libraries",
+                checked = hideWatched,
+                onCheckedChange = { userDataViewModel.setLibraryFilterWatched(it) }
             )
         }
 

--- a/app/src/main/java/com/hritwik/avoid/presentation/viewmodel/library/LibraryItemsPagingSource.kt
+++ b/app/src/main/java/com/hritwik/avoid/presentation/viewmodel/library/LibraryItemsPagingSource.kt
@@ -19,7 +19,8 @@ class LibraryItemsPagingSource(
     private val sortOrder: LibrarySortDirection,
     private val genre: String?,
     private val studio: String?,
-    private val includeItemTypes: String?
+    private val includeItemTypes: String?,
+    private val isPlayed: Boolean? = null
 ) : PagingSource<Int, MediaItem>() {
 
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, MediaItem> {
@@ -70,7 +71,8 @@ class LibraryItemsPagingSource(
                     sortOrder = sortOrder,
                     genre = genre,
                     studio = studio,
-                    includeItemTypes = includeItemTypes
+                    includeItemTypes = includeItemTypes,
+                    isPlayed = isPlayed
                 )
             )) {
                 is NetworkResult.Success -> {

--- a/app/src/main/java/com/hritwik/avoid/presentation/viewmodel/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/hritwik/avoid/presentation/viewmodel/library/LibraryViewModel.kt
@@ -98,7 +98,8 @@ class LibraryViewModel @Inject constructor(
         val sortOrder: LibrarySortDirection,
         val genre: String?,
         val studio: String?,
-        val includeItemTypes: String?
+        val includeItemTypes: String?,
+        val isPlayed: Boolean? = null
     )
     private val pagerCache = mutableMapOf<PagerKey, Flow<PagingData<MediaItem>>>()
     private val _pagerCacheVersion = MutableStateFlow(0)
@@ -948,10 +949,11 @@ class LibraryViewModel @Inject constructor(
         sortOrder: LibrarySortDirection,
         genre: String?,
         studio: String?,
-        includeItemTypes: String?
+        includeItemTypes: String?,
+        isPlayed: Boolean? = null
     ): Flow<PagingData<MediaItem>> {
         val normalizedLibraryIds = libraryIds.filter { it.isNotBlank() }.ifEmpty { listOf(libraryId) }
-        val key = PagerKey(userId, normalizedLibraryIds, accessToken, sortBy, sortOrder, genre, studio, includeItemTypes)
+        val key = PagerKey(userId, normalizedLibraryIds, accessToken, sortBy, sortOrder, genre, studio, includeItemTypes, isPlayed)
         return pagerCache.getOrPut(key) {
             Pager(
                 PagingConfig(
@@ -971,7 +973,8 @@ class LibraryViewModel @Inject constructor(
                     sortOrder = sortOrder,
                     genre = genre,
                     studio = studio,
-                    includeItemTypes = includeItemTypes
+                    includeItemTypes = includeItemTypes,
+                    isPlayed = isPlayed
                 )
             }.flow.cachedIn(viewModelScope)
         }

--- a/app/src/main/java/com/hritwik/avoid/presentation/viewmodel/user/UserDataViewModel.kt
+++ b/app/src/main/java/com/hritwik/avoid/presentation/viewmodel/user/UserDataViewModel.kt
@@ -70,7 +70,9 @@ class UserDataViewModel @Inject constructor(
         val externalPlayerEnabled: Boolean,
         val playerType: PlayerType,
         val directPlayEnabled: Boolean,
-        val hdrFormatPreference: HdrFormatPreference
+        val hdrFormatPreference: HdrFormatPreference,
+        val controlsTimeoutSeconds: Int,
+        val hideWatched: Boolean
     )
 
     private data class PlaybackSettingsBundle(
@@ -85,6 +87,8 @@ class UserDataViewModel @Inject constructor(
         val externalPlayerEnabled: Boolean = PreferenceConstants.DEFAULT_EXTERNAL_PLAYER_ENABLED,
         val directPlayEnabled: Boolean = PreferenceConstants.DEFAULT_DIRECT_PLAY_ENABLED,
         val hdrFormatPreference: HdrFormatPreference = HdrFormatPreference.AUTO,
+        val controlsTimeoutSeconds: Int = PreferenceConstants.DEFAULT_CONTROLS_TIMEOUT_SECONDS,
+        val hideWatched: Boolean = PreferenceConstants.DEFAULT_LIBRARY_FILTER_WATCHED
     )
 
     init {
@@ -152,11 +156,19 @@ class UserDataViewModel @Inject constructor(
                     externalPlayerEnabled = bundle.externalPlayerEnabled,
                     playerType = player,
                     directPlayEnabled = bundle.directPlayEnabled,
-                    hdrFormatPreference = bundle.hdrFormatPreference
+                    hdrFormatPreference = bundle.hdrFormatPreference,
+                    controlsTimeoutSeconds = bundle.controlsTimeoutSeconds,
+                    hideWatched = bundle.hideWatched
                 )
             }
             .combine(preferencesManager.getDirectPlayEnabled()) { settings, directPlay ->
                 settings.copy(directPlayEnabled = directPlay)
+            }
+            .combine(preferencesManager.getControlsTimeoutSeconds()) { settings, timeout ->
+                settings.copy(controlsTimeoutSeconds = timeout)
+            }
+            .combine(preferencesManager.getLibraryFilterWatched()) { settings, hideWatched ->
+                settings.copy(hideWatched = hideWatched)
             }
             .stateIn(
                 viewModelScope,
@@ -173,7 +185,9 @@ class UserDataViewModel @Inject constructor(
                     PreferenceConstants.DEFAULT_EXTERNAL_PLAYER_ENABLED,
                     PlayerType.fromValue(PreferenceConstants.DEFAULT_PLAYER_TYPE),
                     PreferenceConstants.DEFAULT_DIRECT_PLAY_ENABLED,
-                    HdrFormatPreference.fromValue(PreferenceConstants.DEFAULT_HDR_FORMAT_PREFERENCE)
+                    HdrFormatPreference.fromValue(PreferenceConstants.DEFAULT_HDR_FORMAT_PREFERENCE),
+                    PreferenceConstants.DEFAULT_CONTROLS_TIMEOUT_SECONDS,
+                    PreferenceConstants.DEFAULT_LIBRARY_FILTER_WATCHED
                 )
             )
 
@@ -300,6 +314,14 @@ class UserDataViewModel @Inject constructor(
 
     fun setHdrFormatPreference(preference: HdrFormatPreference) {
         viewModelScope.launch { preferencesManager.saveHdrFormatPreference(preference) }
+    }
+
+    fun setControlsTimeoutSeconds(seconds: Int) {
+        viewModelScope.launch { preferencesManager.saveControlsTimeoutSeconds(seconds) }
+    }
+
+    fun setLibraryFilterWatched(hideWatched: Boolean) {
+        viewModelScope.launch { preferencesManager.saveLibraryFilterWatched(hideWatched) }
     }
 
     fun setSubtitleSize(size: String) {

--- a/app/src/main/java/com/hritwik/avoid/utils/constants/PreferenceConstants.kt
+++ b/app/src/main/java/com/hritwik/avoid/utils/constants/PreferenceConstants.kt
@@ -77,6 +77,7 @@ object PreferenceConstants {
     const val KEY_PREFER_HDR_OVER_DV = "prefer_hdr_over_dolby_vision"
     const val KEY_HDR_FORMAT_PREFERENCE = "hdr_format_preference"
     const val KEY_FRAME_RATE_SWITCH_ENABLED = "frame_rate_switch_enabled"
+    const val KEY_CONTROLS_TIMEOUT_SECONDS = "controls_timeout_seconds"
 
     const val KEY_LIBRARY_VIEW_TYPE = "library_view_type"
     const val KEY_LIBRARY_SORT_ORDER = "library_sort_order"
@@ -150,6 +151,8 @@ object PreferenceConstants {
     const val DEFAULT_PREFER_HDR_OVER_DV = false
     const val DEFAULT_HDR_FORMAT_PREFERENCE = "auto"
     const val DEFAULT_FRAME_RATE_SWITCH_ENABLED = false
+    const val DEFAULT_CONTROLS_TIMEOUT_SECONDS = 5
+    const val DEFAULT_LIBRARY_FILTER_WATCHED = false
     const val DEFAULT_SERVER_LEGACY_PLAYBACK = false
     const val DEFAULT_REMEMBER_ACCOUNT = true
 


### PR DESCRIPTION
## Summary
- Adds user-configurable "Hide Watched" setting to filter out watched items from library views
- Global setting accessible in Void Settings > Playback Settings section
- When enabled, items where `userData.played == true` will be hidden

## Changes
- Added `KEY_LIBRARY_FILTER_WATCHED` preference constant with default `false`
- Added getter/setter methods in `PreferencesManager`
- Added `hideWatched` to `PlaybackSettings` data class in `UserDataViewModel`
- Added `isPlayed` parameter through the entire API layer:
  - `JellyfinApiService.getLibraryItems()`
  - `LibraryRepository` interface
  - `LibraryRepositoryImpl`
  - `GetLibraryItemsUseCase`
  - `LibraryItemsPagingSource`
  - `LibraryViewModel`
- Updated `LibraryScreen` to receive and pass `hideWatched` setting
- Added UI toggle in Void Settings using `SettingItemWithSwitch`

## API Logic
| Setting State | API Parameter | Result |
|---------------|---------------|--------|
| `hideWatched = false` (default) | `isPlayed = null` | Show all items |
| `hideWatched = true` | `isPlayed = false` | Show only unplayed items |

## Testing
- Toggle persists across app restarts
- Setting applies globally to all library views
- Default state is OFF (show all items)

Fixes #5